### PR TITLE
Fix crash when the world is null

### DIFF
--- a/common/src/main/java/me/codexadrian/spirit/items/SoulCrystalItem.java
+++ b/common/src/main/java/me/codexadrian/spirit/items/SoulCrystalItem.java
@@ -47,6 +47,7 @@ public class SoulCrystalItem extends Item {
 
     private static List<Component> shiftToolTipComponents(@NotNull ItemStack itemStack, @Nullable Level level) {
         List<Component> list = new ArrayList<>();
+        if(level == null) return;
         Tier tier = SoulUtils.getTier(itemStack, level);
         Component display = Component.translatable(tier == null ? SpiritConfig.getInitialTierName() : tier.displayName()).withStyle(ChatFormatting.GRAY);
         list.add(Component.translatable("misc.spirit.tier", display).withStyle(ChatFormatting.GRAY));

--- a/common/src/main/java/me/codexadrian/spirit/items/SoulCrystalItem.java
+++ b/common/src/main/java/me/codexadrian/spirit/items/SoulCrystalItem.java
@@ -47,7 +47,7 @@ public class SoulCrystalItem extends Item {
 
     private static List<Component> shiftToolTipComponents(@NotNull ItemStack itemStack, @Nullable Level level) {
         List<Component> list = new ArrayList<>();
-        if(level == null) return;
+        if(level == null) return list;
         Tier tier = SoulUtils.getTier(itemStack, level);
         Component display = Component.translatable(tier == null ? SpiritConfig.getInitialTierName() : tier.displayName()).withStyle(ChatFormatting.GRAY);
         list.add(Component.translatable("misc.spirit.tier", display).withStyle(ChatFormatting.GRAY));


### PR DESCRIPTION
Fixed a crash then could be caused when using mods to sort your inventory while the level is null, This happens when sorting in backpacks.

This change will cause the shiftTooltip to be empty while sorting but since that will not be seen anyways should not cause any issues

Crash log: https://gist.github.com/Mattabase/5f65daf9a2d26d4fa49e170e75e897a0